### PR TITLE
BOOCO-A-2229 : Fix the cause of the crash

### DIFF
--- a/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
+++ b/readium/navigator/src/main/java/org/readium/r2/navigator/epub/EpubNavigatorFragment.kt
@@ -1098,9 +1098,7 @@ public class EpubNavigatorFragment internal constructor(
                 )
 
                 is PageResource.EpubReflowable -> pageResource.link
-                else -> throw IllegalStateException(
-                    "Expected EpubFxl or EpubReflowable page resources"
-                )
+                else -> return@launch
             }
             val positionLocator = publication.positionsByResource[link.url()]?.let { positions ->
                 val index = ceil(progression * (positions.size - 1)).toInt()


### PR DESCRIPTION
## Description
* Epub表示時のクラッシュ対応
    * notifyCurrentLocation()は EpubFxl と EpubReflowable しかハンドリングしておらず、Cbz と null は else ブランチで `IllegalStateException`を throwしているので、早期リターンに変更

## StackTrace
https://console.firebase.google.com/u/0/project/booco-app/crashlytics/app/android:jp.co.alc.booco/issues/15a56a31ff0e5ae99bda76adb5ec1199?time=7d&types=crash&sessionEventKey=69932B2B013C000163F3A6E7AB160BEA_2185917268372365526

## Task
* https://notion.so/BOOCO-A-2229